### PR TITLE
Centered content

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -5311,6 +5311,16 @@ img.emojione {
   left: 50%;
   transform: translateX(-50%); }
 
+.side-by-side {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-pack: distribute;
+      justify-content: space-around;
+  -ms-flex-align: center;
+      align-items: center;
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap; }
+
 .footnotes {
   font-style: italic;
   font-size: 1.3rem;

--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -2097,7 +2097,6 @@ table {
         flex-wrap: wrap; }
   .columns.is-vcentered {
     -ms-flex-align: center;
-        -ms-grid-row-align: center;
         align-items: center; }
   @media screen and (min-width: 769px) {
     .columns:not(.is-desktop) {
@@ -2110,7 +2109,6 @@ table {
 
 .tile {
   -ms-flex-align: stretch;
-      -ms-grid-row-align: stretch;
       align-items: stretch;
   -ms-flex: 1;
       flex: 1; }
@@ -2376,8 +2374,7 @@ table {
 :root .fa-rotate-270,
 :root .fa-flip-horizontal,
 :root .fa-flip-vertical {
-  -webkit-filter: none;
-          filter: none; }
+  filter: none; }
 
 .fa-stack {
   position: relative;

--- a/src/sass/_single-post.scss
+++ b/src/sass/_single-post.scss
@@ -55,6 +55,13 @@
     transform: translateX(-50%);
 }
 
+.side-by-side {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
 .footnotes {
     font-style: italic;
     font-size: 1.3rem;


### PR DESCRIPTION
Adds the class `side-by-side` that will center and place next to each other whatever is inside it.

An example:

```html
<div class="side-by-side">
  <a href="...">
    <img class="alt-image" alt="..." src="..." width="226" height="262">
  </a>
  <a href="...">
    <img class="alt-image" alt="..." src="..." width="226" height="262">
  </a>
</div>
```

<img width="787" alt="skjermbilde 2016-11-13 kl 20 45 55" src="https://cloud.githubusercontent.com/assets/520420/20248332/379bb684-a9e2-11e6-8975-41387182ed92.png">

In this case, it's important that the images have a `width` and `height` declared, because they are retina images, and would be way too big if they weren't.

They will position themselves under each other when they collide.

Here, I am also using the class `alt-image` on the images, which makes them not go all the way to the edge on small screens.