### PR TITLE
Change blockquote style to pullquotes

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -4553,7 +4553,7 @@ blockquote {
 blockquote:not(.blockquote),
 .pullquote {
   padding-left: 1.75em;
-  font-size: 1.15em;
+  font-size: 1.3em;
   font-style: italic; }
 
 .blockquote {

--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -4550,15 +4550,13 @@ blockquote {
     blockquote cite a {
       font-weight: normal; }
 
-blockquote,
+blockquote:not(.blockquote),
 .pullquote {
   padding-left: 1.75em;
   font-size: 1.15em;
   font-style: italic; }
 
 .blockquote {
-  font-size: 1em;
-  font-style: normal;
   margin-left: -2.2em;
   padding-left: 1.75em;
   border-left: #4A4A4A 0.4em solid; }

--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -4532,28 +4532,36 @@ hr {
 
 blockquote {
   box-sizing: border-box;
-  margin: 1.75em 0 1.75em -2.2em;
-  padding: 0 0 0 1.75em;
-  border-left: #4A4A4A 0.4em solid; }
+  margin-top: 1.75em;
+  margin-bottom: 1.75em;
+  padding-top: 0;
+  padding-bottom: 0; }
+  blockquote p {
+    margin: 0.8em 0; }
+  blockquote small {
+    display: inline-block;
+    margin: 0.8em 0 0.8em 1.5em;
+    font-size: 0.9em;
+    color: #CCC; }
+    blockquote small:before {
+      content: "\2014 \00A0"; }
+  blockquote cite {
+    font-weight: 700; }
+    blockquote cite a {
+      font-weight: normal; }
 
-blockquote p {
-  margin: 0.8em 0;
+blockquote,
+.pullquote {
+  padding-left: 1.75em;
+  font-size: 1.15em;
   font-style: italic; }
 
-blockquote small {
-  display: inline-block;
-  margin: 0.8em 0 0.8em 1.5em;
-  font-size: 0.9em;
-  color: #CCC; }
-
-blockquote small:before {
-  content: "\2014 \00A0"; }
-
-blockquote cite {
-  font-weight: 700; }
-
-blockquote cite a {
-  font-weight: normal; }
+.blockquote {
+  font-size: 1em;
+  font-style: normal;
+  margin-left: -2.2em;
+  padding-left: 1.75em;
+  border-left: #4A4A4A 0.4em solid; }
 
 mark {
   background-color: #fdffb6; }
@@ -5821,7 +5829,7 @@ img.emojione {
    11. Media Queries - Smaller than 900px
    ========================================================================== */
 @media only screen and (max-width: 900px) {
-  blockquote {
+  blockquote, .pullquote, .blockquote {
     margin-left: 0; }
   .main-header {
     box-sizing: border-box;

--- a/src/sass/_base.scss
+++ b/src/sass/_base.scss
@@ -125,7 +125,7 @@ hr {
     padding: 0;
 }
 
-blockquote {
+.blockquote {
   box-sizing: border-box;
   margin: 1.75em 0 1.75em -2.2em;
   padding: 0 0 0 1.75em;
@@ -156,6 +156,37 @@ blockquote {
   }
 }
 
+blockquote,
+.pullquote {
+  box-sizing: border-box;
+  margin: 1.75em 0 1.75em -2.2em;
+  padding: 0 0 0 1.75em;
+  border-left: #4A4A4A 0.4em solid;
+
+  p {
+    margin: 0.8em 0;
+    font-style: italic;
+  }
+
+  small {
+    display: inline-block;
+    margin: 0.8em 0 0.8em 1.5em;
+    font-size: 0.9em;
+    color: #CCC;
+
+    &:before {
+      content: "\2014 \00A0";
+    }
+  }
+
+  cite {
+    font-weight: 700;
+
+    a {
+      font-weight: normal;
+    }
+  }
+}
 
 mark {
     background-color: #fdffb6;

--- a/src/sass/_base.scss
+++ b/src/sass/_base.scss
@@ -134,6 +134,10 @@ blockquote {
   padding-top: 0;
   padding-bottom: 0;
 
+  p {
+    margin: 0.8em 0;
+  }
+
   small {
     display: inline-block;
     margin: 0.8em 0 0.8em 1.5em;
@@ -156,33 +160,19 @@ blockquote {
 
 blockquote,
 .pullquote {
-  margin-right: 0;
-  margin-left: -2.2em;
-
-  padding-right: 0;
   padding-left: 1.75em;
-
-  border-left: #4A4A4A 0.4em solid;
-
-  p {
-    margin: 0.8em 0;
-    font-style: italic;
-  }
+  font-size: 1.15em;
+  font-style: italic;
 }
 
 .blockquote {
-  margin-right: 0;
+  // Overriding the font-size set on pullquotes
+  font-size: 1em;
+
   margin-left: -2.2em;
-
-  padding-right: 0;
   padding-left: 1.75em;
-
   border-left: #4A4A4A 0.4em solid;
-
-  p {
-    margin: 0.8em 0;
-    font-style: italic;
-  }
+  font-style: normal;
 }
 
 mark {

--- a/src/sass/_base.scss
+++ b/src/sass/_base.scss
@@ -161,7 +161,7 @@ blockquote {
 blockquote:not(.blockquote),
 .pullquote {
   padding-left: 1.75em;
-  font-size: 1.15em;
+  font-size: 1.3em;
   font-style: italic;
 }
 

--- a/src/sass/_base.scss
+++ b/src/sass/_base.scss
@@ -125,16 +125,14 @@ hr {
     padding: 0;
 }
 
-.blockquote {
+blockquote {
   box-sizing: border-box;
-  margin: 1.75em 0 1.75em -2.2em;
-  padding: 0 0 0 1.75em;
-  border-left: #4A4A4A 0.4em solid;
 
-  p {
-    margin: 0.8em 0;
-    font-style: italic;
-  }
+  margin-top: 1.75em;
+  margin-bottom: 1.75em;
+
+  padding-top: 0;
+  padding-bottom: 0;
 
   small {
     display: inline-block;
@@ -156,35 +154,34 @@ hr {
   }
 }
 
-blockquote,
-.pullquote {
-  box-sizing: border-box;
-  margin: 1.75em 0 1.75em -2.2em;
-  padding: 0 0 0 1.75em;
+.blockquote {
+  margin-right: 0;
+  margin-left: -2.2em;
+
+  padding-right: 0;
+  padding-left: 1.75em;
+
   border-left: #4A4A4A 0.4em solid;
 
   p {
     margin: 0.8em 0;
     font-style: italic;
   }
+}
 
-  small {
-    display: inline-block;
-    margin: 0.8em 0 0.8em 1.5em;
-    font-size: 0.9em;
-    color: #CCC;
+blockquote,
+.pullquote {
+  margin-right: 0;
+  margin-left: -2.2em;
 
-    &:before {
-      content: "\2014 \00A0";
-    }
-  }
+  padding-right: 0;
+  padding-left: 1.75em;
 
-  cite {
-    font-weight: 700;
+  border-left: #4A4A4A 0.4em solid;
 
-    a {
-      font-weight: normal;
-    }
+  p {
+    margin: 0.8em 0;
+    font-style: italic;
   }
 }
 

--- a/src/sass/_base.scss
+++ b/src/sass/_base.scss
@@ -158,7 +158,7 @@ blockquote {
   }
 }
 
-blockquote,
+blockquote:not(.blockquote),
 .pullquote {
   padding-left: 1.75em;
   font-size: 1.15em;
@@ -166,10 +166,6 @@ blockquote,
 }
 
 .blockquote {
-  // Overriding things set on pullquotes
-  font-size: 1em;
-  font-style: normal;
-
   margin-left: -2.2em;
   padding-left: 1.75em;
   border-left: #4A4A4A 0.4em solid;

--- a/src/sass/_base.scss
+++ b/src/sass/_base.scss
@@ -154,7 +154,8 @@ blockquote {
   }
 }
 
-.blockquote {
+blockquote,
+.pullquote {
   margin-right: 0;
   margin-left: -2.2em;
 
@@ -169,8 +170,7 @@ blockquote {
   }
 }
 
-blockquote,
-.pullquote {
+.blockquote {
   margin-right: 0;
   margin-left: -2.2em;
 

--- a/src/sass/_base.scss
+++ b/src/sass/_base.scss
@@ -126,31 +126,36 @@ hr {
 }
 
 blockquote {
-    box-sizing: border-box;
-    margin: 1.75em 0 1.75em -2.2em;
-    padding: 0 0 0 1.75em;
-    border-left: #4A4A4A 0.4em solid;
-}
+  box-sizing: border-box;
+  margin: 1.75em 0 1.75em -2.2em;
+  padding: 0 0 0 1.75em;
+  border-left: #4A4A4A 0.4em solid;
 
-blockquote p {
+  p {
     margin: 0.8em 0;
     font-style: italic;
-}
+  }
 
-blockquote small {
+  small {
     display: inline-block;
     margin: 0.8em 0 0.8em 1.5em;
     font-size: 0.9em;
     color: #CCC;
-}
 
-blockquote small:before { content: "\2014 \00A0"; }
+    &:before {
+      content: "\2014 \00A0";
+    }
+  }
 
-blockquote cite {
+  cite {
     font-weight: 700;
+
+    a {
+      font-weight: normal;
+    }
+  }
 }
 
-blockquote cite a { font-weight: normal; }
 
 mark {
     background-color: #fdffb6;

--- a/src/sass/_base.scss
+++ b/src/sass/_base.scss
@@ -166,13 +166,13 @@ blockquote,
 }
 
 .blockquote {
-  // Overriding the font-size set on pullquotes
+  // Overriding things set on pullquotes
   font-size: 1em;
+  font-style: normal;
 
   margin-left: -2.2em;
   padding-left: 1.75em;
   border-left: #4A4A4A 0.4em solid;
-  font-style: normal;
 }
 
 mark {

--- a/src/sass/_media-queries-900.scss
+++ b/src/sass/_media-queries-900.scss
@@ -4,7 +4,7 @@
 
 @media only screen and (max-width: 900px) {
 
-    blockquote {
+    blockquote, .pullquote, .blockquote {
         margin-left: 0;
     }
 


### PR DESCRIPTION
Fixes #21 

This adds styles so that the default markdown blockquotes will be rendered as pull quotes.

All three of these styles will result in a pull quote:

```
>Jeg synes det er veldig sosialt å møte alle man leier direkte til.
```

```html
<blockquote>
  Jeg synes det er veldig sosialt å møte alle man leier direkte til.
</blockquote>
```

```html
<blockquote class="pullquote">
  Jeg synes det er veldig sosialt å møte alle man leier direkte til.
</blockquote>
```

These will look like this:

![Pull quote](https://cloud.githubusercontent.com/assets/520420/22945444/8ecc6c7c-f2f4-11e6-8def-ffcd0efa8b0e.png)

If you want to have the old style, you can add the class "blockquote", like this:

```html
<blockquote class="blockquote">
  Jeg synes det er veldig sosialt å møte alle man leier direkte til.
</blockquote>
```

This will look like this:

![Block quote](https://cloud.githubusercontent.com/assets/520420/22945525/c9ec518c-f2f4-11e6-8e9e-45710baf2032.png)

@chreriksen If you have any feedback on this, now is a good time. If not, then I'll go through with this change tomorrow 👍 